### PR TITLE
fix(deps): bump transitive nanoid to 3.3.18 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3230,9 +3230,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes Dependabot alert [#27](https://github.com/PatrickSt1991/Sportlink.Club.Info.Viewer/security/dependabot/27).

## The vulnerability

`nanoid` before 3.3.18 contains an infinite loop (CWE-835) in `customAlphabet` and `customRandom`: called with `size = 0`, the internal generation loop never satisfies its exit condition and spins forever, hanging the calling thread.

- GHSA-2v37-7h3g-55p8 / CVE-2026-67213
- Severity: high (CVSS v4 8.2)
- Affected: `nanoid < 3.3.18` (and `>= 4.0.0, < 5.1.6`)

## Why Dependabot could not fix it

`nanoid` is not a direct dependency — it is pulled in transitively by `postcss`, which itself comes in through `vite`. There is no manifest entry for Dependabot to bump, so it had nothing to open a PR against.

The good news is that `postcss` declares `nanoid: ^3.3.16`, and the patched `3.3.18` is inside that range. So the fix is a lockfile-only resolution bump — no `package.json` change and no `overrides` block needed.

## The change

`package-lock.json`: `nanoid` `3.3.16` → `3.3.18` (3 lines).

## Verification

- `npm run build` — succeeds, 704 modules transformed
- `npm audit` — 0 vulnerabilities

`nanoid` only runs at build time (PostCSS uses it for internal ID generation), so nothing in the shipped bundle changes behaviour.